### PR TITLE
release/2.0.6 into main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kquiet</groupId>
   <artifactId>browser-scheduler</artifactId>
-  <version>2.0.6-SNAPSHOT</version>
+  <version>2.0.6</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A scheduler of browser jobs supporting customized browser automation.</description>
@@ -547,6 +547,6 @@
     <connection>scm:git:https://github.com/kquiet/browser-scheduler.git</connection>
     <developerConnection>scm:git:https://github.com/kquiet/browser-scheduler.git</developerConnection>
     <url>https://github.com/kquiet/browser-scheduler/tree/main</url>
-    <tag>HEAD</tag>
+    <tag>browser-scheduler-2.0.6</tag>
   </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kquiet</groupId>
   <artifactId>browser-scheduler</artifactId>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>2.0.6-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A scheduler of browser jobs supporting customized browser automation.</description>

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -4,7 +4,6 @@ RUN apk --no-cache add ca-certificates curl jq openjdk17-jre font-noto-cjk 'chro
  && GECKO_URL=`curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.assets[]|select(.name|endswith(".tar.gz"))|.browser_download_url|select(contains("linux64"))'` \
  && cd /usr/local/bin && curl -s -L $GECKO_URL | tar -xz && chmod +x geckodriver \
  && mkdir -p /opt/kquiet/${project.artifactId}/ext \
- && wget -O /opt/kquiet/${project.artifactId}/opentelemetry-javaagent.jar https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar \
  && addgroup kquiet && adduser -G kquiet -D kquiet \
  && chown -R kquiet:kquiet /opt/kquiet/
 

--- a/src/main/resources/browserscheduler.sh
+++ b/src/main/resources/browserscheduler.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec java -javaagent:opentelemetry-javaagent.jar -Dspring.profiles.active=jsonlog -Dotel.exporter.otlp.endpoint=${otlp_endpoint:-http://localhost:4317} -Dotel.resource.attributes=service.name=${project.artifactId},service.version=${project.version} -Dchrome_sandbox=no -cp "lib/:lib/*:ext/:ext/*" org.kquiet.browserscheduler.Launcher
+exec java -Dspring.profiles.active=jsonlog -Dchrome_sandbox=no -cp "lib/:lib/*:ext/:ext/*" org.kquiet.browserscheduler.Launcher


### PR DESCRIPTION
[staging] artifacts deployed to repository; you can use maven to get: mvn dependency:get -Dartifact="org.kquiet:browser-scheduler:2.0.6" -DremoteRepositories="https://oss.sonatype.org/content/groups/staging"