### PR TITLE
release/2.0.7 into main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kquiet</groupId>
   <artifactId>browser-scheduler</artifactId>
-  <version>2.0.6-SNAPSHOT</version>
+  <version>2.0.7-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A scheduler of browser jobs supporting customized browser automation.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
     
-    <auto-browser.version>2.0.5</auto-browser.version>
-    <selenium.version>4.8.1</selenium.version>
-    <slf4j.version>2.0.6</slf4j.version>
-    <logback.version>1.4.5</logback.version>
-    <spring.boot.version>3.0.3</spring.boot.version>
+    <auto-browser.version>2.0.6</auto-browser.version>
+    <selenium.version>4.8.3</selenium.version>
+    <slf4j.version>2.0.7</slf4j.version>
+    <logback.version>1.4.6</logback.version>
+    <spring.boot.version>3.0.5</spring.boot.version>
     
     <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
     

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kquiet</groupId>
   <artifactId>browser-scheduler</artifactId>
-  <version>2.0.7-SNAPSHOT</version>
+  <version>2.0.7</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A scheduler of browser jobs supporting customized browser automation.</description>
@@ -547,6 +547,6 @@
     <connection>scm:git:https://github.com/kquiet/browser-scheduler.git</connection>
     <developerConnection>scm:git:https://github.com/kquiet/browser-scheduler.git</developerConnection>
     <url>https://github.com/kquiet/browser-scheduler/tree/main</url>
-    <tag>HEAD</tag>
+    <tag>browser-scheduler-2.0.7</tag>
   </scm>
 </project>

--- a/src/main/resources/browserscheduler.bat
+++ b/src/main/resources/browserscheduler.bat
@@ -1,2 +1,2 @@
 cd %~dp0
-start "" javaw -Dspring.profiles.active=jsonlog -Dchrome_sandbox=no -Dwebdriver_headless=yes -cp "lib/;lib/*;ext/;ext/*" org.kquiet.browserscheduler.Launcher
+start "" javaw -Dspring.profiles.active=jsonlog -Dchrome_option_args="--no-sandbox,--disable-dev-shm-usage" -Dwebdriver_headless=yes -cp "lib/;lib/*;ext/;ext/*" org.kquiet.browserscheduler.Launcher

--- a/src/main/resources/browserscheduler.sh
+++ b/src/main/resources/browserscheduler.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec java -Dspring.profiles.active=jsonlog -Dchrome_sandbox=no -cp "lib/:lib/*:ext/:ext/*" org.kquiet.browserscheduler.Launcher
+exec java -Dspring.profiles.active=jsonlog -Dchrome_option_args="--no-sandbox,--disable-dev-shm-usage" -cp "lib/:lib/*:ext/:ext/*" org.kquiet.browserscheduler.Launcher


### PR DESCRIPTION
[staging] artifacts deployed to repository; you can use maven to get: mvn dependency:get -Dartifact="org.kquiet:browser-scheduler:2.0.7" -DremoteRepositories="https://oss.sonatype.org/content/groups/staging"